### PR TITLE
omitting breakpoints arguments throws error

### DIFF
--- a/bin/polar-h7-rr
+++ b/bin/polar-h7-rr
@@ -37,6 +37,9 @@ function onstart() {
   say.speak('The measurement has been started!');
   (argv.breakpoints || '')
     .split(',')
+    .filter(function(item) {
+      return String(item) !== '';
+    })
     .map(toSeconds)
     .forEach(function(ms) {
       const at = humanize(ms, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polar-h7",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "bin": "bin/polar-h7-rr",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
if you omit `--breakpoints` then `(argv.breakpoints || '').split(',')` ends up as `['']` and the duration-parser cannot accept empty strings. 